### PR TITLE
Fix dependency because of change in base system

### DIFF
--- a/scripts/mist-hud.js
+++ b/scripts/mist-hud.js
@@ -1,7 +1,7 @@
 // mist-hud.js
 
 import { essenceDescriptions } from './mh-theme-config.js';
-import { StoryTagDisplayContainer } from "/systems/city-of-mist/module/story-tag-window.js";
+import { StoryTagWindow } from "/systems/city-of-mist/module/story-tag-application.js";
 import { CityHelpers } from "/systems/city-of-mist/module/city-helpers.js";
 import { CityDialogs } from "/systems/city-of-mist/module/city-dialogs.js";
 import { moveConfig } from "./mh-theme-config.js";
@@ -1203,7 +1203,7 @@ export class MistHUD extends Application {
     event.stopPropagation();
 
     try {
-        const createdTag = await StoryTagDisplayContainer.prototype.createStoryTag(event);
+        const createdTag = await StoryTagWindow.prototype.createStoryTag(event);
         this.render(false);
     } catch (err) {
         console.error("Error creating a story tag:", err);

--- a/scripts/npc-hud.js
+++ b/scripts/npc-hud.js
@@ -1,6 +1,6 @@
 import { initializeAccordions } from './accordion-handler.js';
 import { detectActiveSystem } from './mh-settings.js';
-import { StoryTagDisplayContainer } from "/systems/city-of-mist/module/story-tag-window.js";
+import { StoryTagWindow } from "/systems/city-of-mist/module/story-tag-application.js";
 import { CityDialogs } from "/systems/city-of-mist/module/city-dialogs.js";
 
 globalThis.activeNpcInfluences = globalThis.activeNpcInfluences || {};


### PR DESCRIPTION
story-tag-window.js is no longer existant in city-of-mist system.
Looks like it was replaced by story-tag-application.js
Furthermore StoryTagDisplayContainer now is handled by StoryTagWindow

Should fix https://github.com/mordachai/mist-hud/issues/31 and https://github.com/mordachai/mist-hud/issues/38